### PR TITLE
Fix: harmonise le message d’erreur avec le nom de l’exécutable simple…

### DIFF
--- a/simple_shell.c
+++ b/simple_shell.c
@@ -11,20 +11,20 @@ int execute_command(char *command)
 {
 	pid_t pid;
 	int status;
-
 	char *newline = strchr(command, '\n');
+
 	if (command == NULL)
 		return (1);
 	if (newline)
 		*newline = '\0';
 	if (strchr(command, ' ') != NULL)
 	{
-		fprintf(stderr, "./shell: No such file or directory\n");
+		fprintf(stderr, "./simple_shell: No such file or directory\n");
 		return (1);
 	}
 	if (command[0] != '/' && command[0] != '.')
 	{
-		fprintf(stderr, "./shell: No such file or directory\n");
+		fprintf(stderr, "./simple_shell: No such file or directory\n");
 		return (1);
 	}
 	pid = fork();
@@ -37,7 +37,7 @@ int execute_command(char *command)
 
 		if (execve(command, argv, environ) == -1)
 		{
-			fprintf(stderr, "./shell: No such file or directory\n");
+			fprintf(stderr, "./simple_shell: No such file or directory\n");
 			exit(1);
 		}
 	}


### PR DESCRIPTION
…_shell

- Remplace tous les messages d’erreur ./shell: par ./simple_shell: pour correspondre à l’exemple du checker.
- Garantit la conformité du shell avec les attentes du projet et du correcteur automatique.