### PR TITLE
Fix: conformité stricte à la norme C90 et gestion dynamique du nom du…

### DIFF
--- a/simple_shell.c
+++ b/simple_shell.c
@@ -7,7 +7,7 @@
 *
 * Return: 0 on success, 1 on failure
 */
-int execute_command(char *command)
+int execute_command(char *command, char *progname)
 {
 	pid_t pid;
 	int status;
@@ -19,12 +19,12 @@ int execute_command(char *command)
 		*newline = '\0';
 	if (strchr(command, ' ') != NULL)
 	{
-		fprintf(stderr, "./simple_shell: No such file or directory\n");
+		fprintf(stderr, "%s: No such file or directory\n", progname);
 		return (1);
 	}
 	if (command[0] != '/' && command[0] != '.')
 	{
-		fprintf(stderr, "./simple_shell: No such file or directory\n");
+		fprintf(stderr, "%s: No such file or directory\n", progname);
 		return (1);
 	}
 	pid = fork();
@@ -37,7 +37,7 @@ int execute_command(char *command)
 
 		if (execve(command, argv, environ) == -1)
 		{
-			fprintf(stderr, "./simple_shell: No such file or directory\n");
+			fprintf(stderr, "%s: No such file or directory\n", progname);
 			exit(1);
 		}
 	}
@@ -56,15 +56,17 @@ int execute_command(char *command)
 *
 * Description: This program continuously prompts the user for a command,
 *              reads the input, and executes it using execve.
+* @argc: nb arguments
+* @argv: list of arguments
 *
 * Return: Always 0 (Success)
 */
-int main(void)
+int main(int argc, char **argv)
 {
 	char *input = NULL; /* Input buffer */
-
 	size_t len = 0;     /* Length of input */
 	ssize_t nread;      /* Number of bytes read */
+	(void)argc;
 
 	/* Infinite loop to continuously read and execute commands */
 	while (1)
@@ -87,7 +89,7 @@ int main(void)
 			continue;
 		}
 
-		execute_command(input);
+		execute_command(input, argv[0]);
 	}
 	free(input); /* Task 1: Free input buffer before exiting */
 	return (0);


### PR DESCRIPTION
… programme

- Place toutes les déclarations de variables au début des blocs pour respecter la norme C90.
- Passe argv[0] à execute_command pour afficher dynamiquement le nom du programme dans les messages d’erreur.
- Garantit la compatibilité avec le checker et une gestion correcte des erreurs selon le nom de l’exécutable.